### PR TITLE
Make package compatible with react 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "homepage": "https://github.com/docccdev/react-overflow-scrolling",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": ">=0.14.0 <16.0.0",
+    "react-dom": ">=0.14.0 <16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",


### PR DESCRIPTION
Fixes a warning in yarn when installing dependencies.

Before:
<img width="867" alt="screen shot 2017-03-28 at 4 42 43 pm" src="https://cloud.githubusercontent.com/assets/1177034/24411255/bdb3fa1c-13d5-11e7-933c-368ad80c4abb.png">

After: 
<img width="792" alt="screen shot 2017-03-28 at 4 43 11 pm" src="https://cloud.githubusercontent.com/assets/1177034/24411278/c6b1de5e-13d5-11e7-9eb0-6fc97354ecfe.png">
